### PR TITLE
fix: match functions in named export check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ module.exports = {
             );
             if (!namedExports.length) return;
             const matchingExport = namedExports.find((item) => {
-              const name = item.declaration?.declarations?.[0]?.id?.name ?? '';
+              const name = item.declaration?.declarations?.[0]?.id?.name ?? item.declaration?.id?.name ?? "";
               return compare(name, filenameSansExt);
             });
             if (!matchingExport)

--- a/test/failingFunctionExport.js
+++ b/test/failingFunctionExport.js
@@ -1,0 +1,3 @@
+export function passingFunctionExport() {
+  return false;
+}

--- a/test/passingFunctionExport.js
+++ b/test/passingFunctionExport.js
@@ -1,0 +1,3 @@
+export function passingFunctionExport() {
+  return true;
+}


### PR DESCRIPTION
This PR fixes an issue where the plugin will throw lint fail if you use `export function` with same name as file instead of `export const`

```ts
// MyApp.tsx
export function MyApp(props) {
   ...
}
```

This will pass lint with this fix applied.