### PR TITLE
:bug: Handles named export objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = {
         return {
           Program: function (node) {
             const filename = context.getFilename();
+            if (filename.includes('NamedObject')) console.error(node);
             const filenameSansExt = basename(filename, extname(filename));
             if (
               ['index', 'types'].includes(filenameSansExt) ||
@@ -24,11 +25,19 @@ module.exports = {
             const namedExports = node.body.filter(
               (item) => item.type === 'ExportNamedDeclaration'
             );
+            if (filename.includes('NamedObject'))
+              console.error(namedExports[0].specifiers);
             if (!namedExports.length) return;
             const matchingExport = namedExports.find((item) => {
               const name =
                 item.declaration?.declarations?.[0]?.id?.name ??
                 item.declaration?.id?.name ??
+                item.specifiers?.find((specifier) =>
+                  compare(
+                    [specifier.exported?.name ?? '', filenameSansExt],
+                    transformers
+                  )
+                )?.exported.name ??
                 '';
               return compare([name, filenameSansExt], transformers);
             });

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ module.exports = {
         return {
           Program: function (node) {
             const filename = context.getFilename();
-            if (filename.includes('NamedObject')) console.error(node);
             const filenameSansExt = basename(filename, extname(filename));
             if (
               ['index', 'types'].includes(filenameSansExt) ||
@@ -25,22 +24,10 @@ module.exports = {
             const namedExports = node.body.filter(
               (item) => item.type === 'ExportNamedDeclaration'
             );
-            if (filename.includes('NamedObject'))
-              console.error(namedExports[0].specifiers);
             if (!namedExports.length) return;
-            const matchingExport = namedExports.find((item) => {
-              const name =
-                item.declaration?.declarations?.[0]?.id?.name ??
-                item.declaration?.id?.name ??
-                item.specifiers?.find((specifier) =>
-                  compare(
-                    [specifier.exported?.name ?? '', filenameSansExt],
-                    transformers
-                  )
-                )?.exported.name ??
-                '';
-              return compare([name, filenameSansExt], transformers);
-            });
+            const matchingExport = namedExports
+              .flatMap(getExportedNames)
+              .some((name) => compare([name, filenameSansExt], transformers));
             if (!matchingExport)
               context.report(node, 'Filename does not match any named exports');
           },
@@ -84,12 +71,28 @@ module.exports = {
   },
 };
 
-const compare = (names, transformers) => {
-  const [name, filename] = names.map((string) =>
-    transformers.reduce((acc, fn) => fn(acc), string)
-  );
-  return name === filename;
+const getExportedNames = (exported) => {
+  const names = [];
+  if (exported.declaration)
+    names.push(
+      ...(exported.declaration.declarations ?? [])
+        .concat(arrayWrap(exported.declaration))
+        .map((declaration) => declaration.id?.name)
+        .filter(Boolean)
+    );
+  if (exported.specifiers)
+    names.push(
+      ...exported.specifiers.map((specifier) => specifier.exported.name)
+    );
+  return names;
 };
+
+const arrayWrap = (value) => (Array.isArray(value) ? value : [value]);
+
+const compare = (names, transformers) =>
+  names
+    .map((string) => transformers.reduce((acc, fn) => fn(acc), string))
+    .reduce((name, filename) => name === filename);
 
 const makeTransformers = (options) => {
   const transformers = [];

--- a/test/failingNamedObjectExport.js
+++ b/test/failingNamedObjectExport.js
@@ -1,0 +1,3 @@
+const passingNamedObjectExport = 'stuff';
+const test = 'more stuff';
+export { passingNamedObjectExport, test };

--- a/test/passingNamedObjectExport.js
+++ b/test/passingNamedObjectExport.js
@@ -1,0 +1,3 @@
+const passingNamedObjectExport = 'stuff';
+const test = 'more stuff';
+export { passingNamedObjectExport, test };


### PR DESCRIPTION
closes #10 

This enables export syntax 

```js
// foo.js
const foo = 'bar';
export { foo }
```